### PR TITLE
Fixes svg void elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 ## Latest Changes
 
+## Version 5.3.3
+
+* Fixes bug with svg element dumping. (#48)[https://github.com/thomasborgen/hypermedia/issues/48]
+
 ## Version 5.3.2
 
 * Fixes `style` attribute rendering.

--- a/hypermedia/images.py
+++ b/hypermedia/images.py
@@ -1,6 +1,7 @@
 from typing_extensions import Unpack
 
 from hypermedia.models import BasicElement, VoidElement
+from hypermedia.models.elements import XMLVoidElement
 from hypermedia.types.attributes import (
     AreaAttrs,
     CanvasAttrs,
@@ -116,82 +117,68 @@ class Svg(BasicElement[AnyChildren, SvgAttrs]):
 # Basic SVG elements. These should hopefully cover most use cases.
 # If they don't, feel free to add them.
 # Alternatively, consider using Image with a `src="my.svg` or css.
-class Path(VoidElement[PathAttrs]):
+class Path(XMLVoidElement[PathAttrs]):
     """Element used to define paths for SVG graphics."""
 
     tag: str = "path"
 
-    def __init__(
-        self, *children: AnyChildren, **attributes: Unpack[PathAttrs]
-    ) -> None:
-        super().__init__(*children, **attributes)
+    def __init__(self, **attributes: Unpack[PathAttrs]) -> None:
+        super().__init__(**attributes)
 
 
-class Rect(VoidElement[RectAttrs]):
+class Rect(XMLVoidElement[RectAttrs]):
     """Element used to define rectangles for SVG graphics."""
 
     tag: str = "rect"
 
-    def __init__(
-        self, *children: AnyChildren, **attributes: Unpack[RectAttrs]
-    ) -> None:
-        super().__init__(*children, **attributes)
+    def __init__(self, **attributes: Unpack[RectAttrs]) -> None:
+        super().__init__(**attributes)
 
 
 class Rectangle(Rect):
     """Alias for `Rect`."""
 
 
-class Circle(VoidElement[CircleAttrs]):
+class Circle(XMLVoidElement[CircleAttrs]):
     """Element used to define circles for SVG graphics."""
 
     tag: str = "circle"
 
-    def __init__(
-        self, *children: AnyChildren, **attributes: Unpack[CircleAttrs]
-    ) -> None:
-        super().__init__(*children, **attributes)
+    def __init__(self, **attributes: Unpack[CircleAttrs]) -> None:
+        super().__init__(**attributes)
 
 
-class Ellipse(VoidElement[EllipseAttrs]):
+class Ellipse(XMLVoidElement[EllipseAttrs]):
     """Element used to define ellipses for SVG graphics."""
 
     tag: str = "ellipse"
 
-    def __init__(
-        self, *children: AnyChildren, **attributes: Unpack[EllipseAttrs]
-    ) -> None:
-        super().__init__(*children, **attributes)
+    def __init__(self, **attributes: Unpack[EllipseAttrs]) -> None:
+        super().__init__(**attributes)
 
 
-class Line(VoidElement[LineAttrs]):
+class Line(XMLVoidElement[LineAttrs]):
     """Element used to define lines for SVG graphics."""
 
     tag: str = "line"
 
-    def __init__(
-        self, *children: AnyChildren, **attributes: Unpack[LineAttrs]
-    ) -> None:
-        super().__init__(*children, **attributes)
+    def __init__(self, **attributes: Unpack[LineAttrs]) -> None:
+        super().__init__(**attributes)
 
 
-class Polyline(VoidElement[PolylineAttrs]):
+class Polyline(XMLVoidElement[PolylineAttrs]):
     """Element used to define polylines for SVG graphics."""
 
     tag: str = "polyline"
 
-    def __init__(
-        self, *children: AnyChildren, **attributes: Unpack[PolylineAttrs]
-    ) -> None:
-        super().__init__(*children, **attributes)
+    def __init__(self, **attributes: Unpack[PolylineAttrs]) -> None:
+        super().__init__(**attributes)
 
 
-class Polygon(VoidElement[PolygonAttrs]):
+class Polygon(XMLVoidElement[PolygonAttrs]):
     """Element used to define polygons for SVG graphics."""
 
     tag: str = "polygon"
 
-    def __init__(
-        self, *children: AnyChildren, **attributes: Unpack[PolygonAttrs]
-    ) -> None:
-        super().__init__(*children, **attributes)
+    def __init__(self, **attributes: Unpack[PolygonAttrs]) -> None:
+        super().__init__(**attributes)

--- a/hypermedia/models/elements.py
+++ b/hypermedia/models/elements.py
@@ -118,3 +118,33 @@ class VoidElement(Generic[TAttrs], Element):
     def __str__(self) -> str:
         """Return tag."""
         return self.tag
+
+
+class XMLVoidElement(Generic[TAttrs], Element):
+    """Same as VoidElement, but for XML. Requires closing tags with `/>`."""
+
+    attributes: TAttrs
+
+    tag: str
+
+    def __init__(
+        self,
+        *,
+        slot: str | None = None,
+        # FIXME: https://github.com/python/typing/issues/1399
+        **attributes: Unpack[TAttrs],  # type: ignore
+    ) -> None:
+        super().__init__(slot=slot, **attributes)
+
+    def dump(self) -> SafeString:
+        """Dump to html."""
+        return SafeString(
+            "<{tag}{attributes} />".format(
+                tag=self.tag,
+                attributes=self._render_attributes(),
+            )
+        )
+
+    def __str__(self) -> str:
+        """Return tag."""
+        return self.tag

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hypermedia"
-version = "5.3.2"
+version = "5.3.3"
 description = "An opinionated way to work with html in pure python with htmx support."
 authors = ["Thomas Borgen <thomasborgen91@gmail.com>"]
 readme = "README.md"

--- a/tests/integration/test_images.py
+++ b/tests/integration/test_images.py
@@ -53,17 +53,26 @@ def test_normal_elements(element: type, result: str) -> None:
     "element,result",
     [
         (Area, "<area>"),
-        (Circle, "<circle>"),
-        (Ellipse, "<ellipse>"),
         (Img, "<img>"),
         (Image, "<img>"),
-        (Line, "<line>"),
-        (Path, "<path>"),
-        (Polygon, "<polygon>"),
-        (Polyline, "<polyline>"),
-        (Rect, "<rect>"),
-        (Rectangle, "<rect>"),
     ],
 )
 def test_void_elements(element: type, result: str) -> None:
+    assert element().dump() == result
+
+
+@pytest.mark.parametrize(
+    "element,result",
+    [
+        (Circle, "<circle />"),
+        (Ellipse, "<ellipse />"),
+        (Line, "<line />"),
+        (Path, "<path />"),
+        (Polygon, "<polygon />"),
+        (Polyline, "<polyline />"),
+        (Rect, "<rect />"),
+        (Rectangle, "<rect />"),
+    ],
+)
+def test_xml_void_elements(element: type, result: str) -> None:
     assert element().dump() == result

--- a/tests/models/basic_element/test_basic_element.py
+++ b/tests/models/basic_element/test_basic_element.py
@@ -6,6 +6,7 @@ from hypermedia.models.elements import (
     ElementList,
     ElementStrict,
     VoidElement,
+    XMLVoidElement,
 )
 from hypermedia.types.types import SafeString
 from tests.utils import TestBasicElement
@@ -98,9 +99,20 @@ def test_all_subclasses_dumps_to_safestring() -> None:
         for sub in VoidElement.__subclasses__()
     )
 
+    assert all(
+        isinstance(sub().dump(), SafeString)
+        for sub in XMLVoidElement.__subclasses__()
+    )
+
     assert isinstance(ElementList().dump(), SafeString)
 
-    skip = {"BasicElement", "ElementList", "ElementStrict", "VoidElement"}
+    skip = {
+        "BasicElement",
+        "ElementList",
+        "ElementStrict",
+        "VoidElement",
+        "XMLVoidElement",
+    }
     assert all(
         isinstance(sub().dump(), SafeString)  # type: ignore
         for sub in Element.__subclasses__()

--- a/tests/models/element/test_svg_elements.py
+++ b/tests/models/element/test_svg_elements.py
@@ -1,0 +1,12 @@
+from hypermedia.images import Line, Polygon, Svg
+
+
+def test_svg_renders_as_expected() -> None:
+    assert Svg().dump() == "<svg></svg>"
+
+
+def test_svg_renders_children_as_expected() -> None:
+    assert (
+        Svg(Line(fill="red"), Polygon(fill="blue")).dump()
+        == "<svg><line fill='red' /><polygon fill='blue' /></svg>"
+    )

--- a/tests/models/element/xml_void_element/test_xml_void_element.py
+++ b/tests/models/element/xml_void_element/test_xml_void_element.py
@@ -1,0 +1,29 @@
+from tests.utils import TestXMLVoidElement
+
+
+def test_tag_rendering() -> None:
+    assert TestXMLVoidElement().dump() == "<test />"
+
+
+def test_id_rendering() -> None:
+    assert TestXMLVoidElement(id="test").dump() == "<test id='test' />"
+
+
+def test_class_rendering() -> None:
+    assert TestXMLVoidElement(classes=["one", "two"]).dump() == (
+        "<test class='one two' />"
+    )
+
+
+def test_attribute_rendering() -> None:
+    assert TestXMLVoidElement(test="green").dump() == "<test test='green' />"
+
+
+def test_all_attributes() -> None:
+    assert TestXMLVoidElement(
+        id="test", classes=["one", "two"], test="green"
+    ).dump() == ("<test id='test' test='green' class='one two' />")
+
+
+def test_to_string() -> None:
+    assert str(TestXMLVoidElement()) == "test"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,5 @@
 from hypermedia.models import BasicElement, Element, VoidElement
+from hypermedia.models.elements import XMLVoidElement
 from hypermedia.types.attributes import GlobalAttrs
 from hypermedia.types.types import AnyChildren, SafeString
 
@@ -17,5 +18,10 @@ class TestBasicElement(BasicElement[AnyChildren, GlobalAttrs]):
 
 
 class TestVoidElement(VoidElement[GlobalAttrs]):
+    __test__ = False  # Not an executable test class
+    tag: str = "test"
+
+
+class TestXMLVoidElement(XMLVoidElement[GlobalAttrs]):
     __test__ = False  # Not an executable test class
     tag: str = "test"


### PR DESCRIPTION
fixes: #48 

SVG is read by an xml decoder following the xml spec and not the html spec. 

XML requires explicit closing of tags with `/>` as opposed to html where void elements (elements that can't have children) can be closed with just the `>`

This fixes that by introducing a `XMLVoidElement` base class that dumps the xml elements correctly.